### PR TITLE
Update __init__.py

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -171,7 +171,7 @@ def GetGenre(title, queryParamName=SC_BYGENRE, query=''):
 
 ####################################################################################################
 @route("/music/shoutcast/track")
-def CreateTrackObject(url, title, summary, fmt, include_container=False):
+def CreateTrackObject(url, title, summary, fmt, include_container=False, **kwargs):
 
 	if fmt == 'mp3':
 		container = Container.MP3


### PR DESCRIPTION
Hi,
some players (PMP, Web Player, Android App, ..) sends these days additional parameter to CreateTrackObject like includeBandwidths, includeRelated and so on. **kwargs prevents such players to block your plugin here. I'm shure you know or use this option from/at similar scenarios. Shoutcast-Plugin wasn't updated some years but it's still used.
Thx
Roland Scholz